### PR TITLE
Fix InlineText method incompatibility with parent class

### DIFF
--- a/src/InlineText.php
+++ b/src/InlineText.php
@@ -9,13 +9,13 @@ class InlineText extends Text
 {
     public $component = 'inline-text-field';
 
-    protected function resolveAttribute($resource, $attribute)
+    protected function resolveAttribute($resource, string $attribute): mixed
     {
         $this->withMeta(['resourceId' => $resource->getKey()]);
         return parent::resolveAttribute($resource, $attribute);
     }
 
-    public function resolve($resource, $attribute = null)
+    public function resolve($resource, ?string $attribute = null): void
     {
         parent::resolve($resource, $attribute);
 


### PR DESCRIPTION
Fixes error:

Declaration of Outl1ne\NovaInlineTextField\InlineText::resolve($resource, $attribute = null) must be compatible with Laravel\Nova\Fields\Field::resolve($resource, ?string $attribute = null): void at /Users/daviddear/Projects/clientproject/vendor/outl1ne/nova-inline-text-field/src/InlineText.php:18)